### PR TITLE
Add GitHub link and logo to all pages

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -13,6 +13,10 @@ website:
         text: Dashboard
       - href: src/about_data.qmd
         text: About the Data
+    right:
+      - icon: github
+        href: https://github.com/b-cubed-eu/euroraccoon
+        aria-label: "GitHub Repository"
 format:
   html:
     theme: flatly

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,6 +103,13 @@ ul.task-list li input[type="checkbox"] {
 <span class="menu-text">About the Data</span></a>
   </li>  
 </ul>
+            <ul class="navbar-nav navbar-nav-scroll ms-auto">
+  <li class="nav-item compact">
+    <a class="nav-link" href="https://github.com/b-cubed-eu/euroraccoon"> <i class="bi bi-github" role="img" aria-label="GitHub Repository">
+</i> 
+<span class="menu-text"></span></a>
+  </li>  
+</ul>
           </div> <!-- /navcollapse -->
             <div class="quarto-navbar-tools">
 </div>

--- a/docs/src/about_data.html
+++ b/docs/src/about_data.html
@@ -141,6 +141,13 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <span class="menu-text">About the Data</span></a>
   </li>  
 </ul>
+            <ul class="navbar-nav navbar-nav-scroll ms-auto">
+  <li class="nav-item compact">
+    <a class="nav-link" href="https://github.com/b-cubed-eu/euroraccoon"> <i class="bi bi-github" role="img" aria-label="GitHub Repository">
+</i> 
+<span class="menu-text"></span></a>
+  </li>  
+</ul>
           </div> <!-- /navcollapse -->
             <div class="quarto-navbar-tools">
 </div>

--- a/docs/src/dashboard.html
+++ b/docs/src/dashboard.html
@@ -112,7 +112,14 @@ ul.task-list li input[type="checkbox"] {
 <span class="menu-text">About the Data</span></a>
   </li>  
 </ul>
-          <div class="quarto-dashboard-links"><a class="quarto-dashboard-link" href="https://github.com/damianooldoni/qmd_dashboard"><i class="bi bi-github"></i></a></div></div> <!-- /navcollapse -->
+            <ul class="navbar-nav navbar-nav-scroll ms-auto">
+  <li class="nav-item compact">
+    <a class="nav-link" href="https://github.com/b-cubed-eu/euroraccoon"> <i class="bi bi-github" role="img" aria-label="GitHub Repository">
+</i> 
+<span class="menu-text"></span></a>
+  </li>  
+</ul>
+          </div> <!-- /navcollapse -->
             <div class="quarto-navbar-tools">
 </div>
       </div> <!-- /container-fluid -->

--- a/src/dashboard.qmd
+++ b/src/dashboard.qmd
@@ -2,9 +2,6 @@
 format: 
   dashboard:
     scrolling: false
-    nav-buttons:
-      - icon: github
-        href: https://github.com/damianooldoni/qmd_dashboard
 ---
 
 # Europe


### PR DESCRIPTION
This pull request includes changes to update the GitHub repository links and navigation structure across multiple files. The most important changes include adding a new GitHub link to the navigation bar and removing outdated GitHub links.